### PR TITLE
trigger circle build from GitHub

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -39,6 +39,8 @@ jobs:
             fi
             docker buildx build \
               ${DOCKER_ARGS} \
+              --label org.opencontainers.image.title="<< pipeline.parameters.image_name >>" \
+              --label org.opencontainers.image.description="<< pipeline.parameters.image_description >>" \
               --tag "<< pipeline.parameters.prefix >><< pipeline.parameters.image_name >>:<< pipeline.parameters.release_tag >>-arm" \
               "<< pipeline.parameters.image_name >>"
 

--- a/.github/workflows/build-publish-fenics.yml
+++ b/.github/workflows/build-publish-fenics.yml
@@ -59,6 +59,15 @@ jobs:
           tags: |
             type=raw,value=${{ github.event.inputs.release_tag }}
 
+      - name: Trigger circleci build for ARM
+        run: |
+          curl \
+            --request POST \
+            --url https://circleci.com/api/v2/project/github/scientificcomputing/packages/pipeline \
+            -u "${{ secrets.CIRCLECI_TOKEN }}:" \
+            --header "Content-Type: application/json" \
+            --data '{ "parameters": ${{ toJSON(github.event.inputs) }} }'
+
       - name: Build and push Docker image
         uses: docker/build-push-action@v3
         with:
@@ -69,4 +78,3 @@ jobs:
           labels: ${{ steps.meta.outputs.labels }}
           cache-from: type=registry,ref=${{ env.REGISTRY }}/${{ github.repository_owner }}/${{ github.event.inputs.image_name }}:${{ github.event.inputs.release_tag }}
           cache-to: type=inline
-


### PR DESCRIPTION
Makes an API request to CircleCI to initiate the arm build

inputs match, so it should create the same image, with a `-arm` suffix on the tag