### PR TITLE
Pin cython before installing MPI and PETSc

### DIFF
--- a/fenics/Dockerfile
+++ b/fenics/Dockerfile
@@ -87,6 +87,7 @@ RUN export DEBIAN_FRONTEND=noninteractive && \
 
 # Install Python packages (via pip)
 RUN python3 -m pip install --upgrade pip setuptools
+RUN python3 -m pip install Cython==0.29.32
 RUN python3 -m pip install pytest pkgconfig
 RUN python3 -m pip install --no-cache-dir mpi4py
 


### PR DESCRIPTION
Ci running at: https://github.com/scientificcomputing/packages/actions/runs/4762146652