### PR TITLE
Bump version to 2023-08-11

### DIFF
--- a/fenics-gmsh/Dockerfile
+++ b/fenics-gmsh/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/scientificcomputing/fenics:2023-04-21
+FROM ghcr.io/scientificcomputing/fenics:2023-08-11
 
 # Dependency versions
 ARG GMSH_VERSION=4_11_1


### PR DESCRIPTION
Update `fenics-gmsh` to use the most recent Docker image of `fenics`