### PR TITLE
Update fenics-gmsh to use fenics:2023-08-14

### DIFF
--- a/fenics-gmsh/Dockerfile
+++ b/fenics-gmsh/Dockerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/scientificcomputing/fenics:2023-08-11
+FROM ghcr.io/scientificcomputing/fenics:2023-08-14
 
 # Dependency versions
 ARG GMSH_VERSION=4_11_1


### PR DESCRIPTION
Use ghcr.io/scientificcomputing/fenics:2023-08-14 as base image in fenics-gmsh